### PR TITLE
SConscript.target.linux: remove -Werror

### DIFF
--- a/SConscript.target.linux
+++ b/SConscript.target.linux
@@ -69,7 +69,6 @@ env.Append(CFLAGS = [
     '-Wcast-align',
     '-Wfloat-equal',
     '-Wformat=2',
-    '-Werror',
     '-Wno-unknown-pragmas',
     '-Wpacked',
     '-Wpointer-arith',


### PR DESCRIPTION
Remove -Werror to avoid a build failure on:

/home/fabrice/buildroot/output/host/i586-buildroot-linux-musl/sysroot/usr/include/sys/fcntl.h:1:2: error: #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h> [-Werror=cpp]
 #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h>
  ^~~~~~~
/home/fabrice/buildroot/output/host/bin/i586-linux-gcc -o build/release/src/target/linux/aj_target_nvram.o -c -pipe -funsigned-char -fno-strict-aliasing -Wall -Waggregate-return -Wbad-function-cast -Wcast-align -Wfloat-equal -Wformat=2 -Werror -Wno-unknown-pragmas -Wpacked -Wpointer-arith -Wshadow -Wundef -Wformat-security -Werror=format-security -Wwrite-strings -Os -DAJ_MAIN -DAJ_NVRAM_SIZE=64000 -DAJ_NVRAM_SIZE_CREDS=10000 -DAJ_NVRAM_SIZE_SERVICES=10000 -DAJ_NVRAM_SIZE_FRAMEWORK=10000 -DAJ_NVRAM_SIZE_ALLJOYNJS=10000 -DAJ_NVRAM_SIZE_RESERVED=14000 -DAJ_NVRAM_SIZE_APPS=10000 -DAJ_NUM_REPLY_CONTEXTS=8 -DNDEBUG -DAJ_TCP -DAJ_ARDP -Idist/include -Ibuild/release/src/external/sha2 -Isrc/external/sha2 -Ibuild/release/src/malloc -Isrc/malloc -Ibuild/release/src src/target/linux/aj_target_nvram.c
scons: *** [build/release/src/aj_authorisation.o] Error 1
cc1: all warnings being treated as errors

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>